### PR TITLE
DocComment wrong for WithoutStrictOrderingFor

### DIFF
--- a/Src/Core/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
+++ b/Src/Core/Equivalency/SelfReferenceEquivalencyAssertionOptions.cs
@@ -442,7 +442,7 @@ namespace FluentAssertions.Equivalency
         }
 
         /// <summary>
-        /// Causes the collection identified by the provided <paramref name="predicate"/> to be compared in the order 
+        /// Causes the collection identified by the provided <paramref name="predicate"/> to be compared ignoring the order 
         /// in which the items appear in the expectation.
         /// </summary>
         public TSelf WithoutStrictOrderingFor(Expression<Func<ISubjectInfo, bool>> predicate)


### PR DESCRIPTION
The code documentation for SelfReferenceEquivalencyAssertionOptions,WithoutStrictOrderingFor 
was wrong.

It implied that order was evaluated.
It seems like a copy paste error as the exact same docComment appears on  WithStrictOrderingFor.

The DocComment is corrected so it now reflects the fact that ordering is ignored

## IMPORTANT 
SINCE FLUENT ASSERTIONS IS CURRENTLY UNDER HEAVY REFACTORING FOR [VERSION 5.0](https://github.com/fluentassertions/fluentassertions/issues/463), WE CURRENTLY ONLY ACCEPT BUGFIX REQUESTS. SORRY FOR THE INCONVENIENCE

* [ ] The [Pull Request](https://help.github.com/articles/using-pull-requests) is targeted at the `master` branch.
* [ ] The code complies with the [Coding Guidelines for C# 3.0, 4.0 and 5.0](http://www.csharpcodingguidelines.com/)/.
* [ ] The changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
* [ ] If the contribution affects the documentation, please include your changes to [**documentation.md**](https://github.com/fluentassertions/fluentassertions/blob/master/docs/documentation.md) in this pull request so the documentation will appear on the [website](http://fluentassertions.com/documentation.html).
